### PR TITLE
Rebuild the .editorconfig to detect duplicates and fine-tune the defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ It includes:
 * Can create projects for binary or source-only packages
 * Code coverage using [Coverlet](https://github.com/coverlet-coverage/coverlet) and [Coveralls.io](https://coveralls.io/)
 * Static code analysis using Roslyn analyzers [StyleCopAnalyzers](https://github.com/DotNetAnalyzers/StyleCopAnalyzers), [Roslynator](https://github.com/dotnet/roslynator), [CSharpGuidelinesAnalyzer](https://github.com/bkoelman/CSharpGuidelinesAnalyzer) and [Meziantou](https://github.com/meziantou/Meziantou.Framework).
-* Auto-formatting using `.editorconfig` and settings honored by [JetBrains Rider](https://www.jetbrains.com/rider/) and [ReSharper](https://www.jetbrains.com/resharper/)
+* Auto-formatting using (a slightly opinionated) `.editorconfig` and settings honored by [JetBrains Rider](https://www.jetbrains.com/rider/) and [ReSharper](https://www.jetbrains.com/resharper/)
 * A [Nuke](https://nuke.build/) C# build script that you can run locally as well as in your CI/CD pipeline
 * A GitHub Actions workflow that builds, tests, packages and publishes your library
 * GitHub issue templates to streamline bug reporting and feature requests

--- a/templates/Source/.editorconfig
+++ b/templates/Source/.editorconfig
@@ -1,9 +1,10 @@
 root = true
 # EditorConfig is awesome: http://EditorConfig.org
 
-# top-most EditorConfig file
+####################################################################
+## Global settings
+####################################################################
 
-# Global settings
 [*]
 end_of_line = crlf
 insert_final_newline = true
@@ -110,13 +111,11 @@ csharp_space_after_dot = false
 csharp_space_after_keywords_in_control_flow_statements = true
 csharp_space_after_semicolon_in_for_statement = true
 csharp_space_around_binary_operators = before_and_after
-csharp_space_around_declaration_statements = do_not_ignore
 csharp_space_before_colon_in_inheritance_clause = true
 csharp_space_before_comma = false
 csharp_space_before_dot = false
 csharp_space_before_open_square_brackets = false
 csharp_space_before_semicolon_in_for_statement = false
-csharp_space_between_attribute_sections = false
 csharp_space_between_empty_square_brackets = false
 csharp_space_between_method_call_empty_parameter_list_parentheses = false
 csharp_space_between_method_call_name_and_opening_parenthesis = false
@@ -127,7 +126,14 @@ csharp_space_between_method_declaration_parameter_list_parentheses = false
 csharp_space_between_parentheses = false
 csharp_space_between_square_brackets = false
 
+####################################################################
+## Rider/ReSharper Settings
+####################################################################
+
+# Keep enough blank lines between code blocks to make it readable.
 resharper_blank_lines_after_multiline_statements = 1
+resharper_blank_lines_around_single_line_auto_property = 1
+resharper_blank_lines_before_case = 1
 
 # Purpose: Don't put elements of an array on new lines, unless the length exceeds the maximum line length.
 resharper_wrap_array_initializer_style = chop_always
@@ -135,214 +141,261 @@ resharper_wrap_array_initializer_style = chop_always
 # Purpose: Always put elements of an object initializer on new lines, unless the length exceeds the maximum line length.
 resharper_wrap_object_and_collection_initializer_style = chop_always
 
-# Purpose: An item within a C# enumeration is missing an Xml documentation header
-# Reason: Some enums are self-explanatory
-dotnet_diagnostic.ca1062.severity = suggestion
+resharper_unused_parameter_local_highlighting = error
+resharper_not_accessed_positional_property_global_highlighting = error
 
-# Purpose: Specify StringComparison
-# Reason: Ignored since we force invariant culture on the csproj level
-dotnet_diagnostic.ca1307.severity = none
+# Do not remove redundant else blocks
+resharper_redundant_if_else_block_highlighting = none
 
-# Purpose: Specify StringComparison
-# Reason: Specify StringComparison for methods that don't use Ordinal by default
-dotnet_diagnostic.ca1310.severity = error
+####################################################################
+## Roslyn Analyzers and Code Fixes
+####################################################################
 
-# Purpose: 'X' is an internal class that is apparently never instantiated. If so, remove the code from the assembly
-# Reason: The class is used, but not directly through the constructor, which is fine. 
-dotnet_diagnostic.ca1812.severity = none
+# Purpose: Field contains the word 'and', which suggests doing multiple thing
+# Rationale: We do not want to enforce this rule in our codebase.
+dotnet_diagnostic.AV1115.severity = suggestion
 
-# Purpose: Properties should not return arrays
-# Reason: Although it's good advice, we should decide this case-by-case
-dotnet_diagnostic.ca1819.severity = suggestion
+# Purpose: Return interfaces to unchangeable collections
+# Rationale: We do not want to enforce this rule in our codebase.
+dotnet_diagnostic.AV1130.severity = suggestion
 
-# Purpose: For improved performance, use the LoggerMessage delegates instead of calling 'LoggerExtensions.LogInformation(ILogger, string?, params object?[])'
-# Reason: For now, we prefer to use explicit checks using IsEnabled
-dotnet_diagnostic.ca1848.severity = none
+# Purpose: null is returned from method which has return type of string, collection or task
+# Rationale: It's a good suggestion, but can be hard to implement.
+dotnet_diagnostic.AV1135.severity = suggestion
 
-# Purpose: Use Task.ConfigureAwait(false) if the current SynchronizationContext is not needed
-# Reason: Not relevant for .NET Core web applications.
-dotnet_diagnostic.ca2007.severity = none
-
-# Purpose: # SA0001: XmlCommentAnalysisDisabled
-# Reason: We don't want to force this
-dotnet_diagnostic.sa0001.severity = none
-
-# Purpose: Use string.Empty for empty string
-# Reason: We don't want to force this
-dotnet_diagnostic.sa1122.severity = none
-
-# Purpose: Prefix local calls with this
-# Reason: We don't want to force this
-dotnet_diagnostic.sa1101.severity = none
-
-# Purpose: A enum should not follow a class
-# Reason: We don't want to force this for a content-only package
-dotnet_diagnostic.sa1201.severity = none
-
-# Purpose: public' members should come before 'private' members
-# Reason: We keep members in order of execution
-dotnet_diagnostic.SA1202.severity = none
-
-# Purpose: Static members should appear before non-static members
-# Reason: We keep members in order of execution
-dotnet_diagnostic.SA1204.severity = none
-
-# Purpose: Code should not contain multiple blank lines in a row
-# Reason: No need to fail a build on that
-dotnet_diagnostic.sa1507.severity = none
-
-# Purpose: A single-line comment within C# code is not preceded by a blank line.
-# Reason: Unnecessarily strict
-dotnet_diagnostic.sa1515.severity = none
-
-# Purpose: File is required to end with a single newline character 
-# Reason: We don't case
-dotnet_diagnostic.sa1518.severity = none
-
-# Purpose: Element parameters should be documented
-# Reason: We don't want to force this
-dotnet_diagnostic.sa1611.severity = none
-
-# Purpose: Element return value should be documented
-# Reason: We don't want to force this
-dotnet_diagnostic.sa1615.severity = none
-
-# Purpose: Generic type parameters should be documented
-# Reason: We don't want to force this
-dotnet_diagnostic.sa1618.severity = none
-
-# Purpose: Element return value should be documented
-# Reason: We don't want to force this
-dotnet_diagnostic.sa1622.severity = none
-
-# Purpose: The property's documentation summary text should begin with: 'Gets or sets'
-# Reason: We don't want to force this
-dotnet_diagnostic.sa1623.severity = none
-
-# Purpose: Documentation text should end with a period
-# Reason: We're not building a library
-dotnet_diagnostic.sa1629.severity = none
-
-# Purpose: The file header is missing or not located at the top of the file
-# Reason: We don't want to force this
-dotnet_diagnostic.sa1633.severity = none
-
-# Purpose: File name should match first type name
-# Reason: To keep the content-only package simple, we keep everything together 
-dotnet_diagnostic.sa1649.severity = none
-
-# Purpose: Elements should be documented
-# Reason: We don't want to force documentation for all elements
-dotnet_diagnostic.sa1600.severity = suggestion
-
-# Purpose: Partial elements should be documented
-# Reason: We don't want to force this
-dotnet_diagnostic.sa1601.severity = none
-
-# Purpose: Enumeration items should be documented
-# Reason: We don't want to force this
-dotnet_diagnostic.sa1602.severity = suggestion
-
-# Purpose: Closing parenthesis should be on line of last parameter
-# Reason: We don't want to force this
-dotnet_diagnostic.sa1111.severity = none
-
-# Purpose: The parameters should begin on the line after the declaration, whenever the parameter span across multiple lines
-# Reason: We don't want to force this
-dotnet_diagnostic.sa1116.severity = none
-
-# Purpose: The parameters should all be placed on the same line or each parameter should be placed on its own lin
-# Reason: We don't want to force this
-dotnet_diagnostic.sa1117.severity = none
-
-# Purpose: Use an overload of 'Contains' that has a StringComparison parameter
-# Reason: Ignored since we force invariant culture on the csproj level
-dotnet_diagnostic.ma0001.severity = none
-
-# Purpose: MA0002 : Use an overload that has a IEqualityComparer<string> or IComparer<string> parameter
-# Reason: Ignored since we force invariant culture on the csproj level
-dotnet_diagnostic.ma0002.severity = none
-
-# Purpose: Use Task.ConfigureAwait(false) if the current SynchronizationContext is not needed
-# Reason: Not relevant for .NET Core web applications.
-dotnet_diagnostic.ma0004.severity = none
-
-# Purpose: Use string.Equals instead of NotEquals operator
-# Reason: Ignored since we force invariant culture on the csproj level
-dotnet_diagnostic.ma0006.severity = none
-
-# Purpose: MA0011 : Use an overload of 'ToString' that has a 'System.IFormatProvider' parameter
-# Reason: Ignored since we force invariant culture on the csproj level
-dotnet_diagnostic.ma0011.severity = none
-
-# Purpose: Fix TODO comment
-# Reason: We don't want to force this
-dotnet_diagnostic.ma0026.severity = suggestion
-
-# Purpose: File name must match type name. 
-# Reason: Too many purposeful violations.
-dotnet_diagnostic.MA0048.severity = none
-
-# Purpose: Closing parenthesis should not be preceded by a space
-# Reason: We don't want to force this
-dotnet_diagnostic.sa1009.severity = none
-
-# Purpose: Code should not contain trailing whitespace 
-# Reason: We don't want to force this
-dotnet_diagnostic.sa1028.severity = none
-
-# Purpose: File may only contain a single type
-# Reason: We keep everything together in this project.
-dotnet_diagnostic.SA1402.severity = none
-
-# Purpose: Use trailing comma in multi-line initialize
-# Reason: We don't want to force this
-dotnet_diagnostic.sa1413.severity = none
-
-# Purpose: Return type in signature for should be an interface to an unchangeable collection
-# Reason: We don't want to force this
-dotnet_diagnostic.av1130.severity = none
-
-# Purpose: A property, method or local function should do only one thing
-# Reason: We don't want to force this
-dotnet_diagnostic.av1115.severity = suggestion
-
-# Purpose: Method contains 8 statements, which exceeds the maximum of 7 statements
-# Reason: We don't want to force this
-dotnet_diagnostic.av1500.severity = none
+# Purpose contains x statements, which exceeds the maximum of 7 statements
+# Rationale: 7 is the ideal Clean Code value, 15 is what we think is reasonable, 40 is the absolute maximum.
+dotnet_diagnostic.AV1500.max_statement_count = 40
+dotnet_diagnostic.AV1500.severity = error
 
 # Purpose: Loop statement contains nested loop
-# Reason: We don't want to completely prevent this. 
-dotnet_diagnostic.av1532.severity = suggestion
+# Rationale: We don't want to completely prevent this.
+dotnet_diagnostic.AV1532.severity = suggestion
 
-# Purpose: Call the more overloaded method from other overloads
-# Reason: We don't want to force this 
-dotnet_diagnostic.av1551.severity = none
+# Purpose: Overloaded method should call another overload
+# Rationale: Does often lead to more complex code
+dotnet_diagnostic.AV1551.severity = suggestion
 
-# Purpose: Argument for parameter 'param' in method calls nested method
-# Reason: Not a real issue in Rider anymore
-dotnet_diagnostic.av1580.severity = none
+# Parameter is invoked with a named argument
+# Rationale: We do not want to enforce this rule in our codebase.
+dotnet_diagnostic.AV1555.severity = none
 
-# Purpose: Argument for parameter 'param' in method calls nested method
-# Reason: Not a real issue in Rider anymore
-dotnet_diagnostic.av1580.severity = none
+# Purpose: Don’t declare signatures with more than 3 parameters
+# Rationale: 3 is the ideal number of parameters for a method, but more than 5 in a constructor is a problem
+dotnet_diagnostic.AV1561.max_parameter_count = 5
+dotnet_diagnostic.AV1561.max_constructor_parameter_count = 8
+dotnet_diagnostic.AV1561.severity = error
 
-# Purpose: AV1706 : Parameter 'p' should have a more descriptive name
-# Reason: Also complains about lambda parameters. See https://github.com/bkoelman/CSharpGuidelinesAnalyzer/issues/147
-dotnet_diagnostic.av1706.severity = none
+# Purpose: Argument for parameter calls nested method
+# Rationale: Modern debuggers allow stepping into nested calls, so no need to avoid them.
+dotnet_diagnostic.AV1580.severity = none
 
-# Purpose: Property 'Username' contains the name of its containing type 'User'. We should make that decision case-by-case
-# Reason: We don't want to judge this case-by-case
-dotnet_diagnostic.av1710.severity = none
+# Purpose: Parameter 'x' should have a more descriptive name
+# Rationale: Not always useful
+dotnet_diagnostic.AV1706.severity = suggestion
 
-# Purpose: Error AV1755 : Name of async method should end with Async or TaskAsync
-# Reason: We don't want to force this
-dotnet_diagnostic.av1755.severity = none
+# Purpose: Field contains the name of its containing type
+# Rationale: It's not smart enough to understand that CustomFormatters is not the same as Formatter
+dotnet_diagnostic.AV1710.severity = suggestion
+
+# Purpose: Name of async method
+# Rationale: We prefer to only use the "Async" suffix if a synchronous and asynchronous version of the method exists.
+dotnet_diagnostic.AV1755.severity = none
+
+# Purpose: Replace call to Nullable<T>.HasValue with null check
+# Rationale: Should be a suggestion, not an error
+dotnet_diagnostic.AV2202.severity = suggestion
 
 # Purpose: Missing XML comment for internally visible type or member
-# Reason: We don't want to force this
-dotnet_diagnostic.av2305.severity = suggestion
+# Rationale: We do not want to enforce this rule in our codebase.
+dotnet_diagnostic.AV2305.severity = suggestion
 
-# Purpose: Pass -warnaserror to the compiler or add <TreatWarningsAsErrors>True</TreatWarningsAsErrors> to your project
-# Reason: It is already enabled, but during a Sonar scan, the scanner switches back causing unnecessary warnings
-dotnet_diagnostic.av2210.severity = none
+# Purpose: Consider making 'RaiseXXX' an event
+# Rationale: Should only be a suggestion
+dotnet_diagnostic.CA1030.severity = suggestion
+
+# Purpose: Change the type of property 'from 'string' to 'System.Uri'
+# Rationale: Not a bad idea, but not always practical in existing codebases.
+dotnet_diagnostic.CA1056.severity = suggestion
+
+# Purpose: In externally visible method  validate parameter 'formattedGraph' is non-null before using it.
+# Rationale: Not a bad idea, but not always practical in existing codebases.
+dotnet_diagnostic.CA1062.severity = suggestion
+
+# Purpose: Method passes a literal string as parameter
+# Rationale: Very specific rule for localizable applications
+dotnet_diagnostic.CA1303.severity = suggestion
+
+# Purpose: Rename virtual/interface member so that it no longer conflicts with the reserved language keyword 'Throw'.
+# Rationale: We only support C#
+dotnet_diagnostic.CA1716.severity = none
+
+# Purpose: Properties should not return arrays
+# Rationale: Although returning arrays has some performance implications, we don't want to force this.
+dotnet_diagnostic.CA1819.severity = suggestion
+
+# Purpose: Use concrete types when possible for improved performance
+# Rationale: Does not need to be enforced in all cases, especially when using interfaces creates less coupling
+dotnet_diagnostic.CA1859.severity = suggestion
+
+# Purpose: Use Task.ConfigureAwait(false) if the current SynchronizationContext is not needed
+# Rationale: Not relevant for .NET Core web applications.
+dotnet_diagnostic.CA2007.severity = none
+
+# Purpose: Pass System.Uri objects instead of strings
+# Rationale: Although nice to have, this rule is not always practical in existing codebases.
+dotnet_diagnostic.CA2234.severity = suggestion
+
+# Purpose: Use string.Equals instead of Equals operator
+# Rationale: Does not improve readability
+dotnet_diagnostic.MA0006.severity = none
+
+# Purpose: Regular expressions should not be vulnerable to Denial of Service attacks
+# Rationale: See https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0009.md
+dotnet_diagnostic.MA0009.severity = suggestion
+
+# Purpose: Use an overload of 'System.ArgumentException' with the parameter name
+# Rationale: We don't want to force this
+dotnet_diagnostic.MA0015.severity = suggestion
+
+# Purpose: Use an explicit StringComparer to compute hash codes
+# Rationale: Too farfetched
+dotnet_diagnostic.MA0021.severity = suggestion
+
+# Purpose: Closing parenthesis should not be preceded by a space
+# Rationale: This conflicts with record constructors
+dotnet_diagnostic.SA1009.severity = none
+
+# Purpose: Code should not contain trailing whitespace
+# Rationale: We don't want to force this.
+dotnet_diagnostic.SA1028.severity = none
+
+# Purpose: Prefix local calls with this
+# Rationale: We don't want to force this
+dotnet_diagnostic.SA1101.severity = none
+
+# Purpose: Generic type constraints should be on their own line
+# Rationale: We don't want to force this
+dotnet_diagnostic.SA1127.severity = none
+
+# Purpose: Ordering rules
+# Rationale: We prefer to order members so we can read code like a book
+dotnet_diagnostic.SA1201.severity = none
+dotnet_diagnostic.SA1202.severity = none
+dotnet_diagnostic.SA1204.severity = none
+
+# Purpose: The parameters should begin on the line after the declaration, whenever the parameter span across multiple lines
+# Rationale: We don't want to force this
+dotnet_diagnostic.SA1116.severity = none
+
+# Purpose: The parameters should all be placed on the same line or each parameter should be placed on its own lin
+# Rationale: We don't want to force this
+dotnet_diagnostic.SA1117.severity = none
+
+# Purpose: Use string.Empty for empty string
+# Rationale: There is no performance difference in modern .NET versions, so no need to enforce this.
+dotnet_diagnostic.SA1122.severity = none
+
+# Purpose: Do not use region
+# Rationale: Is up to the developer to decide if they want to use regions or not.
+dotnet_diagnostic.SA1124.severity = none
+
+# Purpose: Variable '_' should begin with lower-case lette
+# Rationale: Does not understand discard parameters
+dotnet_diagnostic.SA1312.severity = none
+
+# Purpose: Parameter '_' should begin with lower-case lette
+# Rationale: Does not understand discard parameters
+dotnet_diagnostic.SA1313.severity = none
+
+# Purpose: File may only contain a single type
+# Rationale: Although we prefer to have one type per file, we don't want to force this.
+dotnet_diagnostic.SA1402.severity = suggestion
+
+# Purpose: Code analysis suppression should have justification
+# Rationale: If we do it, we have reasons for it.
+dotnet_diagnostic.SA1404.severity = none
+
+# Purpose: Use trailing comma in multi-line initialize
+# Rationale: We don't want to force this
+dotnet_diagnostic.SA1413.severity = none
+
+# Purpose: A closing brace should not be preceded by a blank line
+# Rationale: We don't care
+dotnet_diagnostic.SA1508.severity = none
+
+# Purpose: File is required to end with a single newline character (
+# Rationale: We don't care
+dotnet_diagnostic.SA1518.severity = none
+
+# Purpose: Elements should be documented
+# Rationale: We don't want to force documentation for all elements
+dotnet_diagnostic.SA1600.severity = suggestion
+
+# Purpose: Partial elements should be documented
+# Rationale: We don't want to force this
+dotnet_diagnostic.SA1601.severity = suggestion
+
+# Purpose: Enumeration items should be documented
+# Rationale: We don't want to force this
+dotnet_diagnostic.SA1602.severity = suggestion
+
+# Purpose: Element parameters should be documented
+# Rationale: We don't want to force this
+dotnet_diagnostic.SA1611.severity = suggestion
+
+# Purpose: The parameter documentation for 'because' should be at position 3
+# Rationale: We don't want to force this
+dotnet_diagnostic.SA1612.severity = suggestion
+
+# Purpose: Element return value should be documented
+# Rationale: We don't want to force this
+dotnet_diagnostic.SA1615.severity = suggestion
+
+# Purpose: Generic type parameters should be documented
+# Rationale: We don't want to force this
+dotnet_diagnostic.SA1618.severity = suggestion
+
+# Purpose: Element return value should be documented
+# Rationale: We don't want to force this
+dotnet_diagnostic.sa1622.severity = suggestion
+
+# Purpose: The property's documentation summary text should begin with: 'Gets or sets'
+# Rationale: We don't want to force this
+dotnet_diagnostic.SA1623.severity = suggestion
+
+# Purpose: Documentation text should end with a period
+# Rationale: We don't want to force this
+dotnet_diagnostic.SA1629.severity = none
+
+# Purpose: The file header is missing or not located at the top of the file
+# Rationale: We don't want to force this
+dotnet_diagnostic.SA1633.severity = none
+
+# Purpose: Constructor summary documentation should begin with standard text
+# Rationale: We don't want to force this
+dotnet_diagnostic.SA1642.severity = none
+
+# Purpose: File name should match first type name
+# Rationale: To keep the content-only package simple, we keep everything together
+dotnet_diagnostic.SA1649.severity = none
+
+# Purpose: Use file header
+# Rationale: We don't want to force this
+dotnet_diagnostic.SA1633.severity = none
+
+####################################################################
+## Duplicate rules
+####################################################################
+
+dotnet_diagnostic.AV1210.severity = none # duplicate of CA1031
+dotnet_diagnostic.AV2407.severity = none # duplicate of SA1124
+dotnet_diagnostic.CA1050.severity = none # duplicate of MA0047 (which is more explanatory)
+dotnet_diagnostic.MA0004.severity = none # duplicate of CA2007
+dotnet_diagnostic.MA0011.severity = none # duplicate of CA1305
+dotnet_diagnostic.MA0051.severity = none # duplicate of AV1500
+dotnet_diagnostic.MA0069.severity = none # duplicate of CA2211
+dotnet_diagnostic.RCS1102.severity = none # duplicate of CA1052
+dotnet_diagnostic.RCS1188.severity = none # duplicate of CA1805
+dotnet_diagnostic.RCS1194.severity = none # duplicate of CA1032
+dotnet_diagnostic.SA1401.severity = none # duplicate of CA1051

--- a/templates/Source/MyPackage.Specs/.editorconfig
+++ b/templates/Source/MyPackage.Specs/.editorconfig
@@ -32,6 +32,10 @@ dotnet_diagnostic.CA1822.severity = none
 # Reason: We don't care about this in tests
 dotnet_diagnostic.CA1852.severity = none
 
+# Purpose: XML comment analysis is disabled due to project configuration
+# Reason: We don't need the documentation from the tests
+dotnet_diagnostic.SA0001.severity = none
+
 # Purpose: Elements must be documented
 # Reason: Not needed for tests
 dotnet_diagnostic.SA1600.severity = none


### PR DESCRIPTION
Completely restarted with an empty `.editorconfig` and all Roslyn analyzers enabled and used that to finetune the enabled rules with a bunch of large codebases. 

Solves #31 
