### PR TITLE
Enable generating the `.xml` file containing the package's documentation

### DIFF
--- a/templates/Source/MyPackage/MyPackage.csproj
+++ b/templates/Source/MyPackage/MyPackage.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;netstandard2.1;net47;net8.0</TargetFrameworks>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Nullable>enable</Nullable>
     <LangVersion>default</LangVersion>
 {{ if source_only ~}}


### PR DESCRIPTION
The project build through this template does not output the XML docs as part of the NuGet package. 