### PR TITLE
Minor tweaking of the `.editorconfig`

### DIFF
--- a/templates/Source/.editorconfig
+++ b/templates/Source/.editorconfig
@@ -147,6 +147,9 @@ resharper_not_accessed_positional_property_global_highlighting = error
 # Do not remove redundant else blocks
 resharper_redundant_if_else_block_highlighting = none
 
+# If we use explicit property names in anonymous types, we do that on purpose.
+resharper_redundant_anonymous_type_property_name_highlighting = none
+
 ####################################################################
 ## Roslyn Analyzers and Code Fixes
 ####################################################################


### PR DESCRIPTION
This pull request introduces a small change to the `.editorconfig` file. The change disables the highlighting for redundant property names in anonymous types, ensuring that explicit property names are preserved intentionally.