### PR TITLE
Added JetBrains InspectCode to generate a SARIF file

### DIFF
--- a/templates/Source/.github/workflows/build.yml
+++ b/templates/Source/.github/workflows/build.yml
@@ -48,6 +48,11 @@ jobs:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         file: TestResults/reports/lcov.info
 
+    - name: Upload SARIF file
+      uses: github/codeql-action/upload-sarif@v3
+      with:
+        sarif_file: Artifacts/CodeIssues.sarif
+
     - name: Upload artifacts
       if: always()
       uses: actions/upload-artifact@v4

--- a/templates/Source/Build/Build.cs
+++ b/templates/Source/Build/Build.cs
@@ -77,6 +77,9 @@ class Build : NukeBuild
     [NuGetPackage("PackageGuard", "PackageGuard.dll")]
     Tool PackageGuard;
 
+    [NuGetPackage("JetBrains.ReSharper.GlobalTools", "inspectcode.exe")]
+    Tool InspectCode;
+
     string SemVer;
 
     Target CalculateNugetVersion => _ => _
@@ -126,8 +129,15 @@ class Build : NukeBuild
                 .SetInformationalVersion(GitVersion.InformationalVersion) );
         });
 
-    Target RunTests => _ => _
+    Target RunInspectCode => _ => _
         .DependsOn(Compile)
+        .Executes(() =>
+        {
+            InspectCode($"MyPackage.sln -o={ArtifactsDirectory / "CodeIssues.sarif"} --no-build");
+        });
+
+    Target RunTests => _ => _
+        .DependsOn(Compile, RunInspectCode)
         .Executes(() =>
         {
             TestResultsDirectory.CreateOrCleanDirectory();

--- a/templates/Source/Build/_build.csproj
+++ b/templates/Source/Build/_build.csproj
@@ -16,7 +16,8 @@
     <PackageReference Include="Nuke.Components" Version="9.0.4" />
     <PackageDownload Include="ReportGenerator" Version="[5.2.0]" />
     <PackageDownload Include="GitVersion.Tool" Version="[6.0.2]" />
-    <PackageDownload Include="PackageGuard" Version="[1.4.1]" />
+    <PackageDownload Include="PackageGuard" Version="[1.6.0]" />
+    <PackageDownload Include="JetBrains.ReSharper.GlobalTools" Version="[2025.2.0]" />
   </ItemGroup>
 
 </Project>

--- a/templates/Source/MyPackage.ApiVerificationTests/MyPackage.ApiVerificationTests.csproj
+++ b/templates/Source/MyPackage.ApiVerificationTests/MyPackage.ApiVerificationTests.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-    <PackageReference Include="Pathy" Version="1.2.1">
+    <PackageReference Include="Pathy" Version="1.5.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/templates/Source/MyPackage.Specs/MyPackage.Specs.csproj
+++ b/templates/Source/MyPackage.Specs/MyPackage.Specs.csproj
@@ -21,7 +21,7 @@
         <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       </PackageReference>
 {{~ if open_source ~}}
-      <PackageReference Include="FluentAssertions" Version="8.5.0" />
+      <PackageReference Include="FluentAssertions" Version="8.6.0" />
 {{~ else ~}}
       <PackageReference Include="FluentAssertions" Version="7.2.0" />
 {{~ end ~}}

--- a/templates/Source/README.md
+++ b/templates/Source/README.md
@@ -70,6 +70,7 @@ The template makes a lot of assumptions, so after generating the project, there'
 * Store the PackageGuard cache that appears under `.\packageguard` after a first build in source control to speed-up successive runs
 {{~ if open_source ~}}
 * Adjust the `funding.yml` to allow people to sponsor your project
+* Review the code of conduct to see if it matches your opinions
 {{~ end ~}}
 
 > [!NOTE]


### PR DESCRIPTION
Integrates static code analysis using [JetBrains InspectCode](https://www.jetbrains.com/help/resharper/InspectCode.html) and publishes results as a SARIF report for processing by GitHub. It adds the ReSharper Global Tools to the build tooling, defines a new build target that runs InspectCode after compilation, and outputs a SARIF file to the artifacts directory. The test target now depends on this analysis step, ensuring code analysis runs as part of the build/test pipeline. The CI workflow uploads the generated SARIF file using the CodeQL SARIF upload action. It also updates the PackageGuard tool version.


Closes #50 